### PR TITLE
Use the stateful midi-renderer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "embedded-midi"
 version = "0.1.2"
 edition = "2018"
-rust-version = "1.51"
+rust-version = "1.60"
 
 authors = ["Mendelt Siebenga <msiebenga@gmail.com>"]
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [dependencies]
 nb = "1.0.0"
 embedded-hal = "0.2.6"
-midi-convert = "0.1.0"
+midi-convert = { git = "https://github.com/rust-midi/midi-convert.git", branch = "stateful_rendering" }
 
 [dev-dependencies]
 embedded-hal-mock = "0.8.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ mod tests {
     }
 
     #[test]
-    fn note_on_should_write_successfully() {
+    fn should_write_midi_message() {
         verify_writes(
             &[MidiMessage::NoteOn(0x02.into(), 0x76.into(), 0x34.into())],
             &[0x92, 0x76, 0x34],
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[test]
-    fn note_on_second_note_should_skip_status() {
+    fn should_use_running_status() {
         verify_writes(
             &[
                 MidiMessage::NoteOn(0x02.into(), 0x76.into(), 0x34.into()),
@@ -122,122 +122,5 @@ mod tests {
             ],
             &[0x92, 0x76, 0x34, 0x33, 0x65],
         );
-    }
-
-    #[test]
-    fn note_on_second_note_different_channel_should_not_skip_status() {
-        verify_writes(
-            &[
-                MidiMessage::NoteOn(0x02.into(), 0x76.into(), 0x34.into()),
-                MidiMessage::NoteOn(0x03.into(), 0x33.into(), 0x65.into()),
-            ],
-            &[0x92, 0x76, 0x34, 0x93, 0x33, 0x65],
-        );
-    }
-    #[test]
-    fn note_on_note_off_should_not_skip_status() {
-        verify_writes(
-            &[
-                MidiMessage::NoteOn(0x02.into(), 0x76.into(), 0x34.into()),
-                MidiMessage::NoteOff(0x02.into(), 0x33.into(), 0x65.into()),
-            ],
-            &[0x92, 0x76, 0x34, 0x82, 0x33, 0x65],
-        );
-    }
-    #[test]
-    fn note_off_should_write_successfully() {
-        verify_writes(
-            &[MidiMessage::NoteOff(0x02.into(), 0x76.into(), 0x34.into())],
-            &[0x82, 0x76, 0x34],
-        );
-    }
-    #[test]
-    fn key_pressure_should_write_successfully() {
-        verify_writes(
-            &[MidiMessage::KeyPressure(
-                0x02.into(),
-                0x76.into(),
-                0x34.into(),
-            )],
-            &[0xA2, 0x76, 0x34],
-        );
-    }
-    #[test]
-    fn control_change_should_write_successfully() {
-        verify_writes(
-            &[MidiMessage::ControlChange(
-                0x02.into(),
-                0x76.into(),
-                0x34.into(),
-            )],
-            &[0xB2, 0x76, 0x34],
-        );
-    }
-    #[test]
-    fn program_change_should_write_successfully() {
-        verify_writes(
-            &[MidiMessage::ProgramChange(0x02.into(), 0x76.into())],
-            &[0xC2, 0x76],
-        );
-    }
-    #[test]
-    fn channel_pressure_should_write_successfully() {
-        verify_writes(
-            &[MidiMessage::ChannelPressure(0x02.into(), 0x76.into())],
-            &[0xD2, 0x76],
-        );
-    }
-    #[test]
-    fn pitch_bend_should_write_successfully() {
-        verify_writes(
-            &[MidiMessage::PitchBendChange(
-                0x02.into(),
-                (0x76, 0x34).into(),
-            )],
-            &[0xE2, 0x76, 0x34],
-        );
-    }
-    #[test]
-    fn quarter_frame_should_write_successfully() {
-        verify_writes(&[MidiMessage::QuarterFrame(0x76.into())], &[0xF1, 0x76]);
-    }
-    #[test]
-    fn song_position_pointer_should_write_successfully() {
-        verify_writes(
-            &[MidiMessage::SongPositionPointer((0x76, 0x34).into())],
-            &[0xF2, 0x76, 0x34],
-        );
-    }
-    #[test]
-    fn song_select_should_write_successfully() {
-        verify_writes(&[MidiMessage::SongSelect(0x76.into())], &[0xF3, 0x76]);
-    }
-    #[test]
-    fn tune_request_should_write_successfully() {
-        verify_writes(&[MidiMessage::TuneRequest], &[0xF6]);
-    }
-    #[test]
-    fn timing_clock_should_write_successfully() {
-        verify_writes(&[MidiMessage::TimingClock], &[0xF8]);
-    }
-    #[test]
-    fn start_should_write_successfully() {
-        verify_writes(&[MidiMessage::Start], &[0xFA]);
-    }
-    #[test]
-    fn continue_should_write_successfully() {
-        verify_writes(&[MidiMessage::Continue], &[0xFB]);
-    }
-    #[test]
-    fn stop_should_write_successfully() {
-        verify_writes(&[MidiMessage::Stop], &[0xFC]);
-    }
-    #[test]
-    fn active_sensing_should_write_successfully() {
-        verify_writes(&[MidiMessage::ActiveSensing], &[0xFE]);
-    }
-    #[test]
-    fn reset_should_write_successfully() {
-        verify_writes(&[MidiMessage::Reset], &[0xFF]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ where
 
 #[derive(Debug)]
 pub struct MidiOut<TX> {
-    renderer: MidiRenderer<SerialTransport<TX>>,
+    renderer: MidiRenderer<SerialTransport<TX>, true>,
 }
 
 impl<TX, E> MidiOut<TX>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! *Midi driver on top of embedded hal serial communications*
 
 #![no_std]
-#[warn(missing_debug_implementations)]
+#![warn(missing_debug_implementations)]
 use core::fmt::Debug;
 use embedded_hal::serial;
 use midi_convert::midi_types::MidiMessage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,10 @@ where
 {
     type Error = E;
 
-    fn write(&mut self, value: u8) -> Result<(), Self::Error> {
-        block!(self.0.write(value))
+    fn write(&mut self, bytes: &[u8]) -> Result<(), Self::Error> {
+        bytes
+            .iter()
+            .try_for_each(|value| block!(self.0.write(*value)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ where
     }
 
     pub fn release(self) -> TX {
-        self.renderer.release()
+        self.renderer.release().0
     }
 
     pub fn write(&mut self, message: &MidiMessage) -> Result<(), E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ where
 
 #[derive(Debug)]
 pub struct MidiOut<TX> {
-    renderer: MidiRenderer<TX>,
+    renderer: MidiRenderer<SerialTransport<TX>>,
 }
 
 impl<TX, E> MidiOut<TX>


### PR DESCRIPTION
This PR implements the MidiTransport on top of an embedded serial Writer and uses that to implement a midi interface on top of the midi-convert MidiRenderer.

This is implemented on top of a midi-convert branch so that needs to be merged first before this can be merged.
