### PR TITLE
Upgrade to embedded-hal v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 nb = "1.0.0"
-embedded-hal = "0.2.6"
+embedded-hal-nb = "1.0.0"
 midi-convert = "0.2.0"
 
 [dev-dependencies]
-embedded-hal-mock = "0.8.0"
+embedded-hal-mock = { version = "0.11.1", features = ["eh1"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![no_std]
 #![warn(missing_debug_implementations)]
 use core::fmt::Debug;
-use embedded_hal::serial;
+use embedded_hal_nb::serial;
 use midi_convert::midi_types::MidiMessage;
 
 use midi_convert::{
@@ -88,7 +88,7 @@ where
 mod tests {
     extern crate std;
     use super::*;
-    use embedded_hal_mock::serial;
+    use embedded_hal_mock::eh1::serial;
     use std::vec::Vec;
 
     fn verify_writes(messages: &[MidiMessage], bytes: &[u8]) {


### PR DESCRIPTION
embedded-hal 1.0.0 is released since I while. This PR upgrades the dependencies.